### PR TITLE
[PKG-2189] sktime 0.17.0

### DIFF
--- a/recipe/build_script.bat
+++ b/recipe/build_script.bat
@@ -1,1 +1,0 @@
-%PYTHON% -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/build_script.bat
+++ b/recipe/build_script.bat
@@ -1,1 +1,1 @@
-%PYTHON% -m pip install . --no-deps -vv --no-build-isolation
+%PYTHON% -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/build_script.sh
+++ b/recipe/build_script.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -eux
-
-$PYTHON -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/build_script.sh
+++ b/recipe/build_script.sh
@@ -1,1 +1,4 @@
-$PYTHON -m pip install . --no-deps -vv --no-build-isolation
+#!/usr/bin/env bash
+set -eux
+
+$PYTHON -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,37 +1,33 @@
 {% set name = "sktime" %}
-{% set version = "0.16.0" %}
+{% set version = "0.17.0" %}
 
 package:
   name: sktime-suite
   version: {{ version }}
 
 source:
-  url: https://github.com/alan-turing-institute/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: fd20eab22e138271b2af9b78f3140c469df8505f88cf951a90aacce08839ceee
+  url: https://github.com/sktime/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 75cb18dbc2fc4e15316130e1401e676f568faade8b711b5140e8c2fd1ff60b06
 
 build:
   number: 0
-  skip: true  # [(py==37 and aarch64)]
-  skip: true  # [py<37 or py>39]
+  skip: true  # [py<37 or py>311]
 
 # This section is required to correctly rerender skip statement
 requirements:
-  build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
   host:
     - python
-  run:
-    - python
+    - pip
+    - setuptools
+    - wheel
+    - toml
+    - python-build
 
 outputs:
   - name: sktime
     script: build_script.sh  # [unix]
     script: build_script.bat  # [win]
     requirements:
-      build:
-        - python                                 # [build_platform != target_platform]
-        - cross-python_{{ target_platform }}     # [build_platform != target_platform]
       host:
         - python
         - pip
@@ -42,17 +38,17 @@ outputs:
       run:
         - python
         - deprecated >=1.2.13
+        - numba>=0.53
         - numpy >=1.21.0,<1.25
-        - pandas >=1.1.0,<1.6.0
-        - numba >=0.55
+        - pandas >=1.1.0,<2.0.0
         - scikit-learn >=0.24.0,<1.3.0
-        - statsmodels >=0.12.1
         - scipy >=1.2.0,<2.0.0
       run_constrained:
         - esig ==0.9.7
         - filterpy >=1.4.5
-        - hmmlearn >=0.2.7
         - gluonts >=0.9.0
+        - hmmlearn >=0.2.7
+        - kotsu >=0.3.1
         - matplotlib-base >=3.3.2
         - pmdarima >=1.8.0,!=1.8.1,<3.0.0
         - prophet >=1.1
@@ -62,6 +58,7 @@ outputs:
         - scikit-posthocs >=0.6.5
         - seaborn >=0.11.0
         - statsforecast >=0.5.2
+        - statsmodels >=0.12.1
         - stumpy >=1.5.1
         - tbats >=1.1.0
         - tsfresh >=0.17.0
@@ -85,14 +82,13 @@ outputs:
 
   - name: sktime-all-extras
     build:
-      #FIXME: Extras environment not resolvable on aarch. Needs someone with
-      #arm machine to tests.
-      skip: true  # [aarch64]
-      noarch: python
+      # Skip building this package because many of the dependencies are not available yet
+      skip: true
     requirements:
       run:
         - python
         - {{ pin_subpackage("sktime", max_pin='x.x.x') }}
+        - attrs
         - cloudpickle
         - dask
         - dtw-python
@@ -103,12 +99,14 @@ outputs:
         # - gluonts  # not on CF
         - matplotlib-base
         - mne
+        - numba >=0.53                           # [py<311]
         - pmdarima
         - prophet
         - pykalman
         - pyod
         - scikit-posthocs
         - seaborn
+        # - seasonal  # not on CF
         - statsforecast
         - stumpy
         - tbats
@@ -117,6 +115,8 @@ outputs:
         - xarray
 
     test:
+      requires:
+        - pip
       imports:
         - sktime
         - sktime.classification
@@ -130,18 +130,18 @@ outputs:
         - sktime.utils
 
 about:
-  home: https://github.com/alan-turing-institute/sktime
+  home: https://github.com/sktime/sktime
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
   summary: A unified framework for machine learning with time series
-  doc_url: https://www.sktime.org/en/latest/
-  dev_url: https://github.com/alan-turing-institute/sktime
+  description: A unified framework for machine learning with time series
+  doc_url: https://www.sktime.net/en/latest/
+  dev_url: https://github.com/sktime/sktime
 
 extra:
   recipe-maintainers:
+    - yarnabrina
     - fkiraly
     - dhirschfeld
     - freddyaboulton
-    - lmmentel
-    - mloning

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ outputs:
       run:
         - python
         - deprecated >=1.2.13
-        - numba>=0.53
+        - numba >=0.53
         - numpy >=1.21.0,<1.25
         - pandas >=1.1.0,<2.0.0
         - scikit-learn >=0.24.0,<1.3.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,6 @@ outputs:
         - prophet >=1.1
         - pykalman >=0.9.5
         - pyod >=0.8.0
-        - pystan ==2.19.1.1
         - scikit-posthocs >=0.6.5
         - seaborn >=0.11.0
         - statsforecast >=0.5.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 0
+  # numba is not available on s390x
+  skip: true  # [s390x]
   skip: true  # [py<37 or py>311]
 
 # This section is required to correctly rerender skip statement
@@ -96,10 +98,10 @@ outputs:
         - filterpy
         - h5py
         # - hmmlearn  # not on CF
-        # - gluonts  # not on CF
+        - gluonts
         - matplotlib-base
         - mne
-        - numba >=0.53                           # [py<311]
+        - numba >=0.53
         - pmdarima
         - prophet
         - pykalman
@@ -115,8 +117,6 @@ outputs:
         - xarray
 
     test:
-      requires:
-        - pip
       imports:
         - sktime
         - sktime.classification

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,21 +22,17 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - toml
-    - python-build
 
 outputs:
   - name: sktime
-    script: build_script.sh  # [unix]
-    script: build_script.bat  # [win]
+    build:
+      script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
     requirements:
       host:
         - python
         - pip
         - setuptools
         - wheel
-        - toml
-        - python-build
       run:
         - python
         - deprecated >=1.2.13

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -82,7 +82,7 @@ outputs:
 
   - name: sktime-all-extras
     build:
-      # Skip building this package because many of the dependencies are not available yet
+      # Skip building this package because many of the dependencies are not available yet.
       skip: true
     requirements:
       run:


### PR DESCRIPTION
Changelog: https://www.sktime.net/en/latest/changelog.html
License: https://github.com/sktime/sktime/blob/v0.17.0/LICENSE
Requirements:  
- https://github.com/sktime/sktime/blob/v0.17.0/pyproject.toml
- https://github.com/sktime/sktime/blob/v0.17.0/docs/source/installation.rst#step-3-building-sktime-from-source

Actions:
1. Skip `s390x` because of `numba`
2. Remove generic `requirements/build` and for the `sktime` output
3. Update generic `requirements/host` and remove generic `requirements/run`
4. Update `run` dependencies. Note that the upstream has outdated limitations for missing python 3.11 support but we really have it.
5. Skip building `sktime-all-extras` subpackage because many of the dependencies are not available yet.
6. Update home, dev & doc urls
7. Add `description`

Notes:
- pycaret 3.0.2 (subpackage pycaret-core) requires `sktime>=0.16.1,!=0.17.1,<0.17.2` https://github.com/pycaret/pycaret/blob/fdc3f7d22a4117577340be6d8fe2db2a889e9d82/requirements.txt#L38 so **v0.17.0** fits our requirements